### PR TITLE
Add git-worktree support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for githash
 
+## 0.1.3.3
+
+* Add git-worktree support [#13](https://github.com/snoyberg/githash/issues/13)
+
 ## 0.1.3.2
 
 * Test suite works outside of a Git repo [#12](https://github.com/snoyberg/githash/issues/12)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        githash
-version:     0.1.3.2
+version:     0.1.3.3
 synopsis:    Compile git revision info into Haskell projects
 description: Please see the README and documentation at <https://www.stackage.org/package/githash>
 category:    Development

--- a/test/WorktreeRepoSpec.hs
+++ b/test/WorktreeRepoSpec.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module WorktreeRepoSpec
+    ( spec
+    ) where
+
+import Control.Monad
+import qualified Data.ByteString as SB
+import GitHash
+import System.Directory
+import System.FilePath
+import System.Process
+import Test.Hspec
+import UnliftIO.Temporary
+
+spec :: Spec
+spec =
+    around setupGitRepo $ do
+        describe "getGitInfo" $ do
+            it "it makes sensible git info for a git-worktree repository" $ \fp -> do
+                errOrGi <- getGitInfo fp
+                case errOrGi of
+                    Left err -> expectationFailure $ show err
+                    Right gi -> do
+                        length (giHash gi) `shouldNotBe` 128
+                        giBranch gi `shouldBe` "worktree-branch"
+                        giDirty gi `shouldBe` True
+                        giCommitDate gi `shouldNotBe` []
+                        giCommitCount gi `shouldBe` 1
+                        giCommitMessage gi `shouldBe` "Initial commit"
+        describe "getGitRoot" $ do
+            it "it gets the expected git root for a git-worktree repository" $ \fp ->
+                getGitRoot fp `shouldReturn` Right fp
+
+setupGitRepo :: (FilePath -> IO ()) -> IO ()
+setupGitRepo runTest =
+    withSystemTempDirectory "normal" $ \fp -> do
+        let fp1 = fp </> "1"
+            fp2 = fp </> "2"
+        createDirectoryIfMissing True fp1
+        createDirectoryIfMissing True fp2
+        let runGit args =
+                void $ readCreateProcess ((proc "git" args) {cwd = Just fp1}) ""
+        runGit ["init"]
+        SB.writeFile
+            (fp1 </> "README.md")
+            "This is a readme, you should read it."
+        runGit ["add", "README.md"]
+        runGit
+            [ "-c"
+            , "user.name='Test User'"
+            , "-c"
+            , "user.email='test@example.com'"
+            , "commit"
+            , "-m"
+            , "Initial commit"
+            ]
+        runGit ["branch", "worktree-branch"]
+        runGit ["worktree", "add", fp2, "worktree-branch"]
+        SB.writeFile
+            (fp2 </> "README.md")
+            "This is a readme that has been modified."
+        runTest fp2


### PR DESCRIPTION
This patchset adds support for git-worktree(1) style repossitories. It addresses issue https://github.com/snoyberg/githash/issues/13.

---

I am not quite sure what *exactly* the purpose of `_giFiles` is. For a `git-worktree` repository I just added the `.git` file to it, but depending on what the result is used for we may also want to have the other files in the "root" `.git` added there as well.