### PR TITLE
giTag outputs the most recent tag found in refs/tags namespace.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for githash
 
+## 0.1.5.0
+
+* Add git tag output via git-describe
+
 ## 0.1.4.0
 
 * Add git-describe output

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        githash
-version:     0.1.4.0
+version:     0.1.5.0
 synopsis:    Compile git revision info into Haskell projects
 description: Please see the README and documentation at <https://www.stackage.org/package/githash>
 category:    Development

--- a/src/GitHash.hs
+++ b/src/GitHash.hs
@@ -48,6 +48,7 @@ module GitHash
   , giCommitCount
   , giCommitMessage
   , giDescribe
+  , giTag
     -- * Creators
   , getGitInfo
   , getGitRoot
@@ -83,6 +84,7 @@ data GitInfo = GitInfo
   , _giFiles :: ![FilePath]
   , _giCommitMessage :: !String
   , _giDescribe :: !String
+  , _giTag :: !String
   }
   deriving (Lift, Show)
 
@@ -118,6 +120,11 @@ giCommitMessage = _giCommitMessage
 -- @since 0.1.4.0
 giDescribe :: GitInfo -> String
 giDescribe = _giDescribe
+
+-- | The output of @git describe --always --tags@ for the most recent commit.
+--
+giTag :: GitInfo -> String
+giTag = _giTag
 
 -- | Get a list of files from within a @.git@ directory.
 getGitFilesRegular :: FilePath -> IO [FilePath]
@@ -211,6 +218,8 @@ getGitInfo root = try $ do
   _giCommitMessage <- run ["log", "-1", "--pretty=%B"]
 
   _giDescribe <- run ["describe", "--always"]
+
+  _giTag <- run ["describe", "--always", "--tags"]
 
   return GitInfo {..}
 

--- a/src/GitHash.hs
+++ b/src/GitHash.hs
@@ -123,6 +123,7 @@ giDescribe = _giDescribe
 
 -- | The output of @git describe --always --tags@ for the most recent commit.
 --
+-- @since 0.1.5.0
 giTag :: GitInfo -> String
 giTag = _giTag
 


### PR DESCRIPTION
Added giTag information for any kind of tag (not only the annotated ones).