### PR TITLE
giDescribe: always include the git revision / tests fix / bump version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # ChangeLog for githash
 
+## 0.1.6.0
+
+* Always include patchlevel and hash in git-describe output
+
+* Don't let user's configured initial branch name break tests
+
 ## 0.1.5.0
 
 * Add git tag output via git-describe

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        githash
-version:     0.1.5.0
+version:     0.1.6.0
 synopsis:    Compile git revision info into Haskell projects
 description: Please see the README and documentation at <https://www.stackage.org/package/githash>
 category:    Development

--- a/src/GitHash.hs
+++ b/src/GitHash.hs
@@ -218,7 +218,7 @@ getGitInfo root = try $ do
 
   _giCommitMessage <- run ["log", "-1", "--pretty=%B"]
 
-  _giDescribe <- run ["describe", "--always"]
+  _giDescribe <- run ["describe", "--always", "--long"]
 
   _giTag <- run ["describe", "--always", "--tags"]
 

--- a/test/NormalRepoSpec.hs
+++ b/test/NormalRepoSpec.hs
@@ -24,7 +24,7 @@ spec =
                     Left err -> expectationFailure $ show err
                     Right gi -> do
                         length (giHash gi) `shouldNotBe` 128
-                        giBranch gi `shouldBe` "master"
+                        giBranch gi `shouldBe` initialBranchName
                         giDirty gi `shouldBe` False
                         giCommitDate gi `shouldNotBe` []
                         giCommitCount gi `shouldBe` 1
@@ -40,7 +40,7 @@ setupGitRepo runTest =
         createDirectoryIfMissing True fp
         let runGit args =
                 void $ readCreateProcess ((proc "git" args) {cwd = Just fp}) ""
-        runGit ["init"]
+        runGit ["init", "--initial-branch", initialBranchName]
         SB.writeFile
             (fp </> "README.md")
             "This is a readme, you should read it."
@@ -55,3 +55,6 @@ setupGitRepo runTest =
             , "Initial commit"
             ]
         runTest fp
+
+initialBranchName :: String
+initialBranchName = "main"

--- a/test/RepoWithASubmoduleSpec.hs
+++ b/test/RepoWithASubmoduleSpec.hs
@@ -26,7 +26,7 @@ spec =
                             Left err -> expectationFailure $ show err
                             Right gi -> do
                                 length (giHash gi) `shouldNotBe` 128
-                                giBranch gi `shouldBe` "master"
+                                giBranch gi `shouldBe` initialBranchName
                                 giDirty gi `shouldBe` False
                                 giCommitDate gi `shouldNotBe` []
                                 giCommitCount gi `shouldBe` 1
@@ -51,8 +51,8 @@ setupGitRepo runTest =
                 void $ readCreateProcess ((proc "git" args) {cwd = Just d}) ""
             runGit1 = runGitIn fp1
             runGit2 = runGitIn fp2
-        runGit1 ["init"]
-        runGit2 ["init"]
+        runGit1 ["init", "--initial-branch", initialBranchName]
+        runGit2 ["init", "--initial-branch", initialBranchName]
         SB.writeFile
             (fp2 </> "README.md")
             "This is a readme, you should read it."
@@ -77,3 +77,6 @@ setupGitRepo runTest =
             , "Initial commit"
             ]
         runTest (fp1, fp2)
+
+initialBranchName :: String
+initialBranchName = "main"


### PR DESCRIPTION
> Add git describe's --long flag to ensure that a git revision hash is always shown (--always isn't enough). 
> Eg when tag "1.21" is checked out, show "1.21-0-g7690b85e5", not just "1.21".

I want to always show the git revision in --version output, including for released versions. Hopefully others do as well, so that hard coding this is ok. 

Unfortunately I don't know which git versions support `--long`, but githash doesn't discuss git version and I'm guessing the flag has been around a long time, so I haven't looked further.

Thanks for githash!
