### PR TITLE
Bugfixes: Let `getGitFilesRegular` work with branching and rewording

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # ChangeLog for githash
 
+## 0.1.6.2
+
+* Fixed bugs; now this library's Template Haskell functions are much more
+  likely on recompilation to detect Git update that doesn't affect workspace:
+  e.g. `git switch -c <new_branch>` (equivalently
+  `git checkout -b <new_branch>`) and `git commit --amend --only`.
+  Implemented in [#23](https://github.com/snoyberg/githash/pull/23).
+
 ## 0.1.6.1
 
 * [Support template-haskell 2.17](https://github.com/snoyberg/githash/pull/22)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        githash
-version:     0.1.6.1
+version:     0.1.6.2
 synopsis:    Compile git revision info into Haskell projects
 description: Please see the README and documentation at <https://www.stackage.org/package/githash>
 category:    Development

--- a/src/GitHash.hs
+++ b/src/GitHash.hs
@@ -131,6 +131,23 @@ giTag = _giTag
 
 -- | Get a list of files from within a @.git@ directory.
 getGitFilesRegular :: FilePath -> IO [FilePath]
+-- [Note: Current implementation's limitation]
+-- the current implementation doesn't work right if:
+-- 1. the current branch's name contains Non-ASCII character (due to @B8.unpack@),
+-- 2. the current branch is only in .git/packed-refs, or
+-- 3. the current branch is a symbolic ref to another reference.
+-- In these cases, the file with the name `ref` in the following
+-- code cannot be found in the filesystem (in the cases 1 & 2),
+-- or can be found but will not be updated on commit (in the case 3).
+-- As a result, if a module uses @tGitInfo@ as TH macro
+-- and the target git repo is in one of the conditions 1--3
+-- at the time of compilation, content-change-free commits will fail to
+-- trigger recompilation.
+--
+-- [Note: reftable]
+-- In the near future, the technology called reftable may replace the
+-- Git's reference management. This function's implementation does not
+-- work with reftable, and therefore will need to be updated.
 getGitFilesRegular git = do
   -- a lot of bookkeeping to record the right dependencies
   let hd         = git </> "HEAD"


### PR DESCRIPTION
Fixed several bugs in `getGitFilesRegular`.

1. It now stores `./git/HEAD` as dependency even if you don't have your
HEAD detached.

2. It now strips the trailing newlines from the content of `.git/HEAD`
to get the ref file of the current branch.

With this commit the function does both. Prior to this commit,
commit/ref-level changes that doesn't affect the actual working
directory was often ignored. With the absence of the Item 1,
`git branch -b` was dismissed and not considered as a change by GHC.
Without the Item 2, `git commit --amend --only` was ignored by GHC.