### PR TITLE
Expose giFiles to users

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for githash
 
+## 0.1.7.0
+
+* Expose giFiles to users.
+
 ## 0.1.6.3
 
 * Specify protocol.file.allow=always for latest git [#28](https://github.com/snoyberg/githash/pull/28)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        githash
-version:     0.1.6.3
+version:     0.1.7.0
 synopsis:    Compile git revision info into Haskell projects
 description: Please see the README and documentation at <https://www.stackage.org/package/githash>
 category:    Development

--- a/src/GitHash.hs
+++ b/src/GitHash.hs
@@ -49,6 +49,7 @@ module GitHash
   , giCommitMessage
   , giDescribe
   , giTag
+  , giFiles
     -- * Creators
   , getGitInfo
   , getGitRoot
@@ -128,6 +129,12 @@ giDescribe = _giDescribe
 -- @since 0.1.5.0
 giTag :: GitInfo -> String
 giTag = _giTag
+
+-- | The files used to determine whether recompilation is necessary in splices.
+--
+-- @since 0.1.7.0
+giFiles :: GitInfo -> [FilePath]
+giFiles = _giFiles
 
 -- | Get a list of files from within a @.git@ directory.
 getGitFilesRegular :: FilePath -> IO [FilePath]


### PR DESCRIPTION
This PR exposes `giFiles` to users. This is useful when writing `Q` expressions in other libraries that depend on Git information, so that one can `addDependentFile` suitably. Directly using the pre-defined splices is hard in these cases, since `Code m a` is opaque.