### PR TITLE
fix for #26: strip "drive-folder" from path returned by `git rev-parse`

### DIFF
--- a/src/GitHash.hs
+++ b/src/GitHash.hs
@@ -72,6 +72,7 @@ import System.Directory
 import System.Exit
 import System.FilePath
 import System.IO.Error (isDoesNotExistError)
+import System.Info (os)
 import System.Process
 import Text.Read (readMaybe)
 
@@ -264,7 +265,25 @@ getGitInfo root = try $ do
 --
 -- @since 0.1.0.0
 getGitRoot :: FilePath -> IO (Either GitHashException FilePath)
-getGitRoot dir = fmap (normalise . takeWhile (/= '\n')) `fmap` (runGit dir ["rev-parse", "--show-toplevel"])
+getGitRoot dir = do
+  gitRoot <- runGit dir ["rev-parse", "--show-toplevel"]
+  let process path = case (os, path) of
+        ("mingw32", '/' : _) ->
+          concat -- build path back
+            . drop 1 -- remove first element
+            . splitOn '/' -- win doesn't allow '/' in names, it is separator only
+            $ path
+        _ -> path
+  pure $ fmap (normalise . takeWhile (/= '\n')) gitRoot
+ where
+  splitOn :: (Eq a) => a -> [a] -> [[a]]
+  splitOn _ [] = []
+  splitOn needle xs =
+    let (prefix, rest) = break (== needle) xs
+        rest' = dropWhile (== needle) rest
+     in case prefix of
+          [] -> splitOn needle rest'
+          _ -> (needle : prefix) : splitOn needle rest'
 
 runGit :: FilePath -> [String] -> IO (Either GitHashException String)
 runGit root args = do

--- a/src/GitHash.hs
+++ b/src/GitHash.hs
@@ -274,7 +274,7 @@ getGitRoot dir = do
             . splitOn '/' -- win doesn't allow '/' in names, it is separator only
             $ path
         _ -> path
-  pure $ fmap (normalise . takeWhile (/= '\n')) gitRoot
+  pure $ fmap (normalise . process . takeWhile (/= '\n')) gitRoot
  where
   splitOn :: (Eq a) => a -> [a] -> [[a]]
   splitOn _ [] = []


### PR DESCRIPTION
Seems, like problems like #26 caused by different path handling.

Windows have two path separators, `\` and `/`, former is preferred. Absolute path has drive letter prepended, but both separators can be used: both `C:\path\to\repo\` and `C:/path/to/repo` are valid.
Tools from MSYS2 uses Unix-style path, where drive letter prepended like an ordinary directory, so they generally consume (and emit!) path like this `/c/path/to/repo`.

If Git is installed in MSYS2, `git rev-parse --show-toplevel` returns path like `/c/path/to/repo`. `normalise` replaces secondary separator with primary and makes path looks like `\c\path\to\repo`. `readProcess` implicitly prepends (though I have no proofs!) current drive letter path to be searched becomes `C:\c\path\to\repo`, and most likely it doesn't exist! _(I tried to create repo at `C:/c/path/to/repo/`, and `githash` took info from it, not from `C:/path/to/repo/`!)_

Quick solution is to strip drive folder from path. Since Windows allows '/' only as path separator and not in names, this should be pretty straightforward. But since 'Git for windows' returns path with correct reference to drive (`C:/path/to/repo`) we have to check not only platform we are running on (I did it with `System.Info.os`), but also the first symbol of path, to make sure we it's `/` and not drive letter already, so we won't corrupt path for folks whose git returns Windows-style path.

Also, WSL have to be considered, but I have no machine with it, so cannot test there.