### PR TITLE
Make better error when path does not exist

### DIFF
--- a/src/GitHash.hs
+++ b/src/GitHash.hs
@@ -73,6 +73,7 @@ import System.Exit
 import System.FilePath
 import System.IO.Error (isDoesNotExistError)
 import System.Process
+import System.IO (hPutStrLn, stderr)
 import Text.Read (readMaybe)
 
 -- | Various pieces of information about a Git repository.
@@ -221,8 +222,14 @@ getGitFilesForWorktree git = do
 -- | Get a list of dependent git related files.
 getGitFiles :: FilePath -> IO [FilePath]
 getGitFiles git = do
+  exists <- doesPathExist git
   isDir <- doesDirectoryExist git
-  if isDir then getGitFilesRegular git else getGitFilesForWorktree git
+  case (exists, isDir) of
+    (True, True) -> getGitFilesRegular git
+    (True, False) -> getGitFilesForWorktree git
+    (False, _) -> do
+      hPutStrLn stderr $ "Path " <> git <> " does not exists!"
+      pure []
 
 -- | Get the 'GitInfo' for the given root directory. Root directory
 -- should be the directory containing the @.git@ directory.


### PR DESCRIPTION
This is "brother-pull request" for #31 
First, there should be no invalid paths, but if they happen, we got misleading error message (see [issue 26](https://github.com/snoyberg/githash/issues/26#issuecomment-1245686616)).  `doesDirExists` returns `False` if either path does not exist or it's not a directory. If file doesn't exists code execution goes to `getGitFilesForWorktree` and leads to strange error message.

So, we can also check if path exists at all **and** it's directory, so we can show user better error message.